### PR TITLE
Remove test linter from default bundle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,18 @@ Add the config to a `.eslintrc` file or the `eslintConfig` object in `package.js
 }
 ```
 
+### Testing
+
+A module for test-specific rules is available.
+
+Add the config to a `.eslintrc` file or the `eslintConfig` object in `package.json` using the ESLint `extends` attribute:
+
+```json
+{
+  "extends": "trails/test"
+}
+```
+
 ## License
 [MIT](https://github.com/trailsjs/eslint-config-trails/blob/master/LICENSE)
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ module.exports = {
     'eslint-config-trails/rules/recommended',
     'eslint-config-trails/rules/node',
     'eslint-config-trails/rules/style',
-    'eslint-config-trails/rules/test',
     'eslint-config-trails/rules/es6'
   ],
   rules: {}

--- a/rules/test.js
+++ b/rules/test.js
@@ -2,5 +2,9 @@ module.exports = {
   'env': {
     'mocha': true,
     'jest': true
+  },
+  rules: {
+    // Testing-specific rules here
   }
 };
+

--- a/test.js
+++ b/test.js
@@ -1,0 +1,6 @@
+module.exports = {
+  extends: [
+    'eslint-config-trails/index',
+    'eslint-config-trails/rules/test'
+  ]
+};


### PR DESCRIPTION
- Add a module 'test.js' in root directory that extends the default bundle with test rules.  Remove existing test module from main bundle, so the developer will need to explicitly ask for the test rules config in testing folders.
  Remove empty object for adding more rules in /test.js. Those should really just go in rules/test.js
