### PR TITLE
Changes to add support ESLint 2.x

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,3 @@
-'use strict'
-
 module.exports = {
   env: {
     node: true
@@ -8,5 +6,5 @@ module.exports = {
   // unable to extends from a module inside of the .eslintrc file
   // Also avoids committing node_modules with a link to the modules
   // Ideal test would allow it to lint itself using its own rules
-  extends: 'eslint:recommended'
+  extends: './index.js'
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,7 @@
 module.exports = {
-  env: {
-    node: true
-  },
   // This config is linting itself according to the recommended rules since we are
   // unable to extends from a module inside of the .eslintrc file
   // Also avoids committing node_modules with a link to the modules
   // Ideal test would allow it to lint itself using its own rules
-  extends: './index.js'
+  extends: './default.js'
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,10 +1,12 @@
-{
-  "env": {
-    "node": true
+'use strict'
+
+module.exports = {
+  env: {
+    node: true
   },
   // This config is linting itself according to the recommended rules since we are
   // unable to extends from a module inside of the .eslintrc file
   // Also avoids committing node_modules with a link to the modules
   // Ideal test would allow it to lint itself using its own rules
-  "extends": "eslint:recommended"
+  extends: 'eslint:recommended'
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ node_js:
 notifications:
   emails: false
 
-before_install:
-- npm install eslint
-
 deploy:
   provider: npm
   email: hello@trailsjs.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
 - '4'
 - stable
 
+script:
+- npm run lint
+
 notifications:
   emails: false
 

--- a/default.js
+++ b/default.js
@@ -4,6 +4,5 @@ module.exports = {
     './rules/es6.js',
     './rules/node.js',
     './rules/style.js'
-  ],
-  rules: {}
+  ]
 };

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 module.exports = {
   extends: [
     './rules/recommended.js',
+    './rules/es6.js',
     './rules/node.js',
-    './rules/style.js',
-    './rules/es6.js'
+    './rules/style.js'
   ],
   rules: {}
 };

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 module.exports = {
   extends: [
-    'eslint-config-trails/rules/recommended',
-    'eslint-config-trails/rules/node',
-    'eslint-config-trails/rules/style',
-    'eslint-config-trails/rules/es6'
+    './rules/recommended.js',
+    './rules/node.js',
+    './rules/style.js',
+    './rules/es6.js'
   ],
   rules: {}
 };

--- a/package.json
+++ b/package.json
@@ -1,24 +1,31 @@
 {
   "name": "eslint-config-trails",
-  "version": "1.0.4",
   "description": "Trails.js eslint config",
-  "main": "index.js",
-  "scripts": {
-    "lint": "eslint .",
-    "test": "eslint . --debug"
+  "version": "1.0.4",
+  "bugs": {
+    "url": "https://github.com/trailsjs/eslint-config-trails/issues"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/trailsjs/eslint-config-trails.git"
+  "dependencies": {},
+  "devDependencies": {
+    "eslint": "^2.8.0"
   },
+  "engines": {
+    "node": ">=4.0.0"
+  },
+  "homepage": "https://github.com/trailsjs/eslint-config-trails",
   "keywords": [
     "eslint",
     "eslintconfig",
     "trails"
   ],
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/trailsjs/eslint-config-trails/issues"
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/trailsjs/eslint-config-trails.git"
   },
-  "homepage": "https://github.com/trailsjs/eslint-config-trails"
+  "scripts": {
+    "lint": "eslint .",
+    "test": "eslint . --debug"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "trails"
   ],
   "license": "MIT",
-  "main": "index.js",
+  "main": "default.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/trailsjs/eslint-config-trails.git"

--- a/react.js
+++ b/react.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: [
-    'eslint-config-trails/index',
-    'eslint-config-trails/rules/react'
+    './index.js',
+    './rules/react.js'
   ],
   rules: {}
 };

--- a/react.js
+++ b/react.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: [
     './index.js',
     './rules/react.js'
-  ],
-  rules: {}
+  ]
 };

--- a/rules/es6.js
+++ b/rules/es6.js
@@ -2,24 +2,8 @@ module.exports = {
   'env': {
     'es6': true
   },
-  'ecmaFeatures': {
-    'arrowFunctions': true,
-    'blockBindings': true,
-    'classes': true,
-    'defaultParams': true,
-    'destructuring': false,
-    'forOf': true,
-    'generators': false,
-    'modules': true,
-    'objectLiteralComputedProperties': true,
-    'objectLiteralDuplicateProperties': false,
-    'objectLiteralShorthandMethods': true,
-    'objectLiteralShorthandProperties': true,
-    'restParams': false,
-    'spread': false,
-    'superInFunctions': true,
-    'templateStrings': true,
-    'jsx': true
+  'parserOptions': {
+    'ecmaVersion': 6
   },
   'rules': {
     // disallow modifying variables that are declared using const

--- a/rules/node.js
+++ b/rules/node.js
@@ -3,6 +3,19 @@ module.exports = {
     'node': true
   },
   'rules': {
-    'no-console': 2
+    'no-console': 2,
+    // ESLint no longer supports disabling some still unsuported ES 2015 features, so we need to use
+    // this rule to disable that syntax
+    'no-restricted-syntax': [
+      2,
+      // Rest parameters (not to be confused with rest arguments)
+      'RestElement',
+      // Default function parameters
+      'AssignmentPattern',
+      // Destructuring assignment
+      'ObjectPattern',
+      // Experimental object/rest spread
+      'ExperimentalRestProperty'
+    ]
   }
 };

--- a/rules/react.js
+++ b/rules/react.js
@@ -1,7 +1,9 @@
 module.exports = {
   'plugins': ['react'],
-  'ecmaFeatures': {
-    'jsx': true
+  'parserOptions': {
+    'ecmaFeatures': {
+      'jsx': true
+    }
   },
   'rules': {
     // Enforce boolean attributes notation in JSX

--- a/rules/test.js
+++ b/rules/test.js
@@ -7,4 +7,3 @@ module.exports = {
     'no-console': 0
   }
 };
-

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: [
-    'eslint-config-trails/index',
-    'eslint-config-trails/rules/test'
+    './index.js',
+    './rules/test.js'
   ]
 };

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: [
-    './index.js',
+    './default.js',
     './rules/test.js'
   ]
 };


### PR DESCRIPTION
These changes allow us to achieve the following:
1. Lint these config files using this very config
2. Use ESLint 2.x

These changes introduce the following issues:
1. We can no longer extend from this config using only `"trails"` - now we need to use at least `"trails/default"`. I expect this to be a bug in ESLint and plan to open an issue to have this resolved.

Some tweaks have been introduced along the way that should have no impact on functionality. All in all, this looks like a breaking change, so if you'd like to merge and release, I recommend doing so as a 2.0.

Closes #13.
