### PR TITLE
[fix] Troubleshoot eslint-config-react no-did-mount-set-state rule

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -16,7 +16,7 @@ module.exports = {
     // Prevent variables used in JSX to be incorrectly marked as unused
     'react/jsx-uses-vars': 2,
     // Prevent usage of setState in componentDidMount
-    'react/no-did-mount-set-state': [2, 'allow-in-func'],
+    'react/no-did-mount-set-state': 2,
     // Prevent usage of setState in componentDidUpdate
     'react/no-did-update-set-state': 2,
     // Prevent usage of unknown DOM property


### PR DESCRIPTION
[fix] API for the rule 'react/no-did-mount-set-state' appears to have changed. Previous setting of 'allow-in-func' appears to be the default behavior of this rule now.

https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
